### PR TITLE
Allow consumers to use custom kubeconfig contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added fields to ClusterBuilder structs to allow consumers to use custom kubeconfig contexts.
+
 ## [1.0.2] - 2024-04-29
 
 ### Added

--- a/pkg/clusterbuilder/client_test.go
+++ b/pkg/clusterbuilder/client_test.go
@@ -1,6 +1,7 @@
 package clusterbuilder
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/giantswarm/cluster-standup-teardown/pkg/clusterbuilder/providers/capa"
@@ -70,7 +71,7 @@ func Test_GetClusterBuilderForContext(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if cb != tc.expected {
+			if !reflect.DeepEqual(cb, tc.expected) {
 				t.Fatalf("Actual value didn't match expected value\n\nexpected: %q\n\nactual: %q", tc.expected, cb)
 			}
 		})

--- a/pkg/clusterbuilder/providers/capa/cluster.go
+++ b/pkg/clusterbuilder/providers/capa/cluster.go
@@ -18,7 +18,9 @@ var (
 )
 
 // ClusterBuilder is the CAPA ClusterBuilder
-type ClusterBuilder struct{}
+type ClusterBuilder struct {
+	CustomKubeContext string
+}
 
 // NewClusterApp builds a new CAPA cluster App
 func (c *ClusterBuilder) NewClusterApp(clusterName string, orgName string, clusterValuesOverrides []string, defaultAppsValuesOverrides []string) *application.Cluster {
@@ -43,5 +45,10 @@ func (c *ClusterBuilder) NewClusterApp(clusterName string, orgName string, clust
 
 // KubeContext returns the known KubeConfig context that this builder expects
 func (c *ClusterBuilder) KubeContext() string {
+
+	if c.CustomKubeContext != "" {
+		return c.CustomKubeContext
+	}
+
 	return "capa"
 }

--- a/pkg/clusterbuilder/providers/capa/managed_controlplane_cluster.go
+++ b/pkg/clusterbuilder/providers/capa/managed_controlplane_cluster.go
@@ -17,8 +17,10 @@ var (
 	baseManagedDefaultAppsValues string
 )
 
-// ClusterBuilder is the CAPA EKS ClusterBuilder
-type ManagedClusterBuilder struct{}
+// ManagedClusterBuilder is the CAPA EKS ClusterBuilder
+type ManagedClusterBuilder struct {
+	CustomKubeContext string
+}
 
 // NewClusterApp builds a new CAPA EKS cluster App
 func (c *ManagedClusterBuilder) NewClusterApp(clusterName string, orgName string, clusterValuesOverrides []string, defaultAppsValuesOverrides []string) *application.Cluster {
@@ -43,5 +45,8 @@ func (c *ManagedClusterBuilder) NewClusterApp(clusterName string, orgName string
 
 // KubeContext returns the known KubeConfig context that this builder expects
 func (c *ManagedClusterBuilder) KubeContext() string {
+	if c.CustomKubeContext != "" {
+		return c.CustomKubeContext
+	}
 	return "eks"
 }

--- a/pkg/clusterbuilder/providers/capa/private_cluster.go
+++ b/pkg/clusterbuilder/providers/capa/private_cluster.go
@@ -20,7 +20,9 @@ var (
 )
 
 // PrivateClusterBuilder is the private CAPA ClusterBuilder
-type PrivateClusterBuilder struct{}
+type PrivateClusterBuilder struct {
+	CustomKubeContext string
+}
 
 // NewClusterApp builds a new private CAPA cluster App
 func (c *PrivateClusterBuilder) NewClusterApp(clusterName string, orgName string, clusterValuesOverrides []string, defaultAppsValuesOverrides []string) *application.Cluster {
@@ -56,5 +58,8 @@ func (c *PrivateClusterBuilder) NewClusterApp(clusterName string, orgName string
 
 // KubeContext returns the known KubeConfig context that this builder expects
 func (c *PrivateClusterBuilder) KubeContext() string {
+	if c.CustomKubeContext != "" {
+		return c.CustomKubeContext
+	}
 	return "capa-private-proxy"
 }

--- a/pkg/clusterbuilder/providers/capv/cluster.go
+++ b/pkg/clusterbuilder/providers/capv/cluster.go
@@ -26,7 +26,9 @@ var (
 )
 
 // ClusterBuilder is the CAPV ClusterBuilder
-type ClusterBuilder struct{}
+type ClusterBuilder struct {
+	CustomKubeContext string
+}
 
 // NewClusterApp builds a new CAPV cluster App
 func (c *ClusterBuilder) NewClusterApp(clusterName string, orgName string, clusterValuesOverrides []string, defaultAppsValuesOverrides []string) *application.Cluster {
@@ -65,5 +67,8 @@ func (c *ClusterBuilder) NewClusterApp(clusterName string, orgName string, clust
 
 // KubeContext returns the known KubeConfig context that this builder expects
 func (c *ClusterBuilder) KubeContext() string {
+	if c.CustomKubeContext != "" {
+		return c.CustomKubeContext
+	}
 	return "capv"
 }

--- a/pkg/clusterbuilder/providers/capvcd/cluster.go
+++ b/pkg/clusterbuilder/providers/capvcd/cluster.go
@@ -24,7 +24,9 @@ var (
 )
 
 // ClusterBuilder is the CAPVCD ClusterBuilder
-type ClusterBuilder struct{}
+type ClusterBuilder struct {
+	CustomKubeContext string
+}
 
 // NewClusterApp builds a new CAPVCD cluster App
 func (c *ClusterBuilder) NewClusterApp(clusterName string, orgName string, clusterValuesOverrides []string, defaultAppsValuesOverrides []string) *application.Cluster {
@@ -57,5 +59,8 @@ func (c *ClusterBuilder) NewClusterApp(clusterName string, orgName string, clust
 
 // KubeContext returns the known KubeConfig context that this builder expects
 func (c *ClusterBuilder) KubeContext() string {
+	if c.CustomKubeContext != "" {
+		return c.CustomKubeContext
+	}
 	return "capvcd"
 }

--- a/pkg/clusterbuilder/providers/capz/cluster.go
+++ b/pkg/clusterbuilder/providers/capz/cluster.go
@@ -18,7 +18,9 @@ var (
 )
 
 // ClusterBuilder is the CAPZ ClusterBuilder
-type ClusterBuilder struct{}
+type ClusterBuilder struct {
+	CustomKubeContext string
+}
 
 // NewClusterApp builds a new CAPZ cluster App
 func (c *ClusterBuilder) NewClusterApp(clusterName string, orgName string, clusterValuesOverrides []string, defaultAppsValuesOverrides []string) *application.Cluster {
@@ -43,5 +45,8 @@ func (c *ClusterBuilder) NewClusterApp(clusterName string, orgName string, clust
 
 // KubeContext returns the known KubeConfig context that this builder expects
 func (c *ClusterBuilder) KubeContext() string {
+	if c.CustomKubeContext != "" {
+		return c.CustomKubeContext
+	}
 	return "capz"
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2961

### What does this PR do?

Allow consumers to use custom kubeconfig contexts for ClusterBuilders.

Tested on https://github.com/giantswarm/cluster-test-suites/pull/282

### Checklist

- [x] CHANGELOG.md has been updated
