### PR TITLE
Support unified cluster-aws app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reduce prom volume size in test clusters
 
+### Added
+
+- Add support for unified cluster-aws app.
+
 ## [1.1.0] - 2024-05-12
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	dario.cat/mergo v1.0.0
 	github.com/giantswarm/apiextensions-application v0.6.1
-	github.com/giantswarm/clustertest v0.20.1
+	github.com/giantswarm/clustertest v0.21.0
 	github.com/onsi/gomega v1.33.1
 	github.com/spf13/cobra v1.8.0
 	sigs.k8s.io/controller-runtime v0.14.5

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkPJa+rXKBr9e0p+6nd8aw3A=
 github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/clustertest v0.20.1 h1:0H/S1Hb+GYj027Awoq20S/Mq9axN9JQVui/OxsyttYs=
-github.com/giantswarm/clustertest v0.20.1/go.mod h1:HT7dW/kX1dzeHw+ina8vwv6P0X23u7A4p3IS+YcV6LU=
+github.com/giantswarm/clustertest v0.21.0 h1:r/EkXaQ4xmk3k66fEKrWp6ztib3d+Q8QtU+8MFMkJ6g=
+github.com/giantswarm/clustertest v0.21.0/go.mod h1:qBTNLdfn/kYpAKl1oSuOZRolSG805umQgZAusERPJck=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=
 github.com/giantswarm/k8smetadata v0.23.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.45.0 h1:4g1Fnpkf4gjxiZtFPCEIfEnEWVIpoTXj1yij4hxaOok=

--- a/pkg/clusterbuilder/providers/capa/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capa/values/cluster_values.yaml
@@ -25,3 +25,8 @@ global:
       spotInstances:
         enabled: true
         maxPrice: 0.2960
+
+  apps:
+    externalDns:
+      values:
+        triggerLoopOnEvent: true

--- a/pkg/clusterbuilder/providers/capa/values/private-cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capa/values/private-cluster_values.yaml
@@ -59,3 +59,18 @@ global:
         enabled: true
         maxPrice: 0.2960
 
+  apps:
+    certManager:
+      values:
+        serviceAccount:
+          annotations:
+            eks.amazonaws.com/role-arn: "{{ .ClusterName }}-CertManager-Role"
+        giantSwarmClusterIssuer:
+          acme:
+            http01:
+              enabled: false
+            dns01:
+              route53:
+                enabled: true
+                # TODO Use a variable as soon as it is available.
+                region: "eu-north-1"

--- a/pkg/standup/standup.go
+++ b/pkg/standup/standup.go
@@ -8,12 +8,13 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/giantswarm/clustertest"
 	"github.com/giantswarm/clustertest/pkg/application"
 	clustertestclient "github.com/giantswarm/clustertest/pkg/client"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/wait"
-	cr "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Client is the client responsible for handling standing up a given cluster
@@ -57,6 +58,12 @@ func (c *Client) Standup(cluster *application.Cluster) (*application.Cluster, er
 	ctx := context.Background()
 	applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 20*time.Minute)
 	defer cancelApplyCtx()
+
+	skipsDefaultApps, err := cluster.UsesUnifiedClusterApp()
+	Expect(err).NotTo(HaveOccurred())
+	if skipsDefaultApps {
+		logger.Log("Deploying only unified %s app (with default apps) and skipping %s app.", cluster.ClusterApp.AppName, cluster.DefaultAppsApp.AppName)
+	}
 
 	client, err := c.Framework.ApplyCluster(applyCtx, cluster)
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/standup/standup.go
+++ b/pkg/standup/standup.go
@@ -8,13 +8,12 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	cr "sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/giantswarm/clustertest"
 	"github.com/giantswarm/clustertest/pkg/application"
 	clustertestclient "github.com/giantswarm/clustertest/pkg/client"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/wait"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Client is the client responsible for handling standing up a given cluster
@@ -58,12 +57,6 @@ func (c *Client) Standup(cluster *application.Cluster) (*application.Cluster, er
 	ctx := context.Background()
 	applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 20*time.Minute)
 	defer cancelApplyCtx()
-
-	skipsDefaultApps, err := cluster.UsesUnifiedClusterApp()
-	Expect(err).NotTo(HaveOccurred())
-	if skipsDefaultApps {
-		logger.Log("Deploying only unified %s app (with default apps) and skipping %s app.", cluster.ClusterApp.AppName, cluster.DefaultAppsApp.AppName)
-	}
 
 	client, err := c.Framework.ApplyCluster(applyCtx, cluster)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/roadmap/issues/3119

With cluster-aws v0.76.0 and newer, default apps are deployed with cluster-aws and default-apps-aws app is not deployed anymore.

Note: The latest cluster-aws release is v0.75.0 and the [default apps addition](https://github.com/giantswarm/cluster-aws/pull/581) is not yet merged (but it has been tested and it's ready to be merged). This PR assumes that the [default apps addition](https://github.com/giantswarm/cluster-aws/pull/581) will be merged and that v0.76.0 will be released.

⚠️ This should be used in cluster-test-suites only after cluster-aws v0.76.0 has been released. Otherwise cluster-test-suites will fail.

### Checklist

- [x] CHANGELOG.md has been updated
