### PR TITLE
reduce prom volume size in capvcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce prom volume size in capvcd
+
 ## [1.1.0] - 2024-05-12
 
 ### Changed

--- a/pkg/clusterbuilder/providers/capa/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capa/values/cluster_values.yaml
@@ -3,6 +3,8 @@ global:
     name: "{{ .ClusterName }}"
     description: "E2E Test cluster"
     organization: "{{ .Organization }}"
+    labels:
+      monitoring.giantswarm.io/prometheus-volume-size: small
 
   controlPlane:
     containerdVolumeSizeGB: 15

--- a/pkg/clusterbuilder/providers/capa/values/managed-cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capa/values/managed-cluster_values.yaml
@@ -3,6 +3,8 @@ global:
     name: "{{ .ClusterName }}"
     description: "E2E Test cluster"
     organization: "{{ .Organization }}"
+    labels:
+      monitoring.giantswarm.io/prometheus-volume-size: small
 
   controlPlane:
     # disable logging to save cost

--- a/pkg/clusterbuilder/providers/capa/values/private-cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capa/values/private-cluster_values.yaml
@@ -3,6 +3,8 @@ global:
     name: "{{ .ClusterName }}"
     description: "E2E Test cluster"
     organization: "{{ .Organization }}"
+    labels:
+      monitoring.giantswarm.io/prometheus-volume-size: small
 
   connectivity:
     baseDomain: gaws.gigantic.io

--- a/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml
@@ -3,6 +3,11 @@ organization: "{{ .Organization }}"
 
 baseDomain: test.gigantic.io
 
+global:
+  metadata:
+    labels:
+      monitoring.giantswarm.io/prometheus-volume-size: small
+
 controlPlane:
   replicas: 1
   image:

--- a/pkg/clusterbuilder/providers/capvcd/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capvcd/values/cluster_values.yaml
@@ -36,3 +36,5 @@ providerSpecific:
 metadata:
   description: "E2E Test cluster"
   organization: "{{ .Organization }}"
+  labels:
+    monitoring.giantswarm.io/prometheus-volume-size: small

--- a/pkg/clusterbuilder/providers/capz/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capz/values/cluster_values.yaml
@@ -3,6 +3,8 @@ global:
     name: "{{ .ClusterName }}"
     description: "E2E Test cluster"
     organization: "{{ .Organization }}"
+    labels:
+      monitoring.giantswarm.io/prometheus-volume-size: small
   providerSpecific:
     location: "westeurope"
     subscriptionId: 6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3


### PR DESCRIPTION
### What does this PR do?

Reduce size of prometheus volumes to 30GB.

https://docs.giantswarm.io/vintage/getting-started/observability/monitoring/prometheus/volume-size/

### Checklist

- [x] CHANGELOG.md has been updated
