### PR TITLE
Prevent cluster deletion with env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reduce prom volume size in test clusters
 
+### Added
+
+- Added support for the `E2E_WC_KEEP` environment variable that prevent cluster deletion during the teardown phase
+
 ## [1.1.0] - 2024-05-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ standup --provider aws --context capa
 
 Cleans up a workload cluster previously created by `standup`. Makes use of the `kubeconfig` and `results.json` produced by `standup`.
 
+#### Preventing cluster deletion
+
+It is possible to prevent cluster deletion during the teardown stage by setting the `E2E_WC_KEEP` environment variable to anything other than `false`. If this env var is found the teardown function will not actually perform any actions against the cluster and will instead just log out to the logger that deletion has been skipped and the user must then maunally clean up the resources in the MC.
+
 #### Install
 
 ```shell

--- a/pkg/teardown/teardown.go
+++ b/pkg/teardown/teardown.go
@@ -2,11 +2,15 @@ package teardown
 
 import (
 	"context"
+	"os"
+	"strings"
 
 	"github.com/giantswarm/clustertest"
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/logger"
 )
+
+const keepWCEnvVar = "E2E_WC_KEEP"
 
 // Client is the client responsible for handling cluster teardown
 type Client struct {
@@ -23,5 +27,15 @@ func New(framework *clustertest.Framework) *Client {
 // Teardown handles removing the given workload cluster from the MC
 func (c *Client) Teardown(cluster *application.Cluster) error {
 	logger.Log("Deleting cluster: %s", cluster.Name)
+
+	keep := strings.ToLower(os.Getenv(keepWCEnvVar))
+	if keep != "" && keep != "false" {
+		logger.Log("⚠️ The %s env var is set, skipping deletion of workload cluster", keepWCEnvVar)
+		logger.Log("⚠️ This means the Cluster '%s' will remain on the management cluster only until the cluster-cleaner decides to remove it later. To disable the cluster-cleaner behavior please manually add the 'alpha.giantswarm.io/ignore-cluster-deletion' annotation to your test cluster.", cluster.Name)
+		logger.Log("⚠️ Please be sure to manually delete the '%s' Organisation when you are finished.", cluster.Organization.Name)
+
+		return nil
+	}
+
 	return c.Framework.DeleteCluster(context.Background(), cluster)
 }

--- a/pkg/teardown/teardown.go
+++ b/pkg/teardown/teardown.go
@@ -10,7 +10,7 @@ import (
 	"github.com/giantswarm/clustertest/pkg/logger"
 )
 
-const keepWCEnvVar = "E2E_WC_KEEP"
+const keepWCEnvVar = "E2E_WC_KEEP" //nolint:gosec
 
 // Client is the client responsible for handling cluster teardown
 type Client struct {


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/giantswarm/giantswarm/issues/30698

Introduces support for a new environment variable - `E2E_WC_KEEP` - that will allow skipping of the cluster deletion step. This can be set when running the cluster-test-suites locally to prevent the WC being removed at the end to help with debugging of failures and issues.

### Checklist

- [x] CHANGELOG.md has been updated
