### PR TITLE
Update IsUpgrade to support updating Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated clustertest to v1.10.0 and changed the `IsUpgrade` support in Standup to handle setting the Release version used by the cluster before upgrade.
+
 ## [1.10.0] - 2024-06-25
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 require (
 	dario.cat/mergo v1.0.0
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/clustertest v1.9.0
+	github.com/giantswarm/clustertest v1.10.0
 	github.com/onsi/gomega v1.33.1
 	github.com/spf13/cobra v1.8.1
 	sigs.k8s.io/controller-runtime v0.18.4

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/clustertest v1.9.0 h1:1U+nB7B1HYHqwkhIN5lVSaxhydeYmIy9OxwhNdTk0sI=
-github.com/giantswarm/clustertest v1.9.0/go.mod h1:549o+JD/bwCn3hy9+OgswBA6WVA2so58aaKM0Jom2cA=
+github.com/giantswarm/clustertest v1.10.0 h1:npJARVngBhqP+XtKEsPUCSvwRDmQfkOAVFwAMRTpD/U=
+github.com/giantswarm/clustertest v1.10.0/go.mod h1:549o+JD/bwCn3hy9+OgswBA6WVA2so58aaKM0Jom2cA=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=
 github.com/giantswarm/k8smetadata v0.25.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.57.0 h1:IMmho55Qq+WE+frJXcTBhx19+J54xwu/j4+pGU5YecA=


### PR DESCRIPTION
### What does this PR do?

Updated clustertest to v1.10.0 and changed the `IsUpgrade` support in Standup to handle setting the Release version used by the cluster before upgrade.

### Checklist

- [x] CHANGELOG.md has been updated
