### PR TITLE
Update CAPV values after removal of nodeClasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `capv` cluster values following removal of nodeClasses.
+
 ## [1.12.1] - 2024-07-05
 
 ### Fixed

--- a/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml
@@ -26,10 +26,7 @@ global:
     resourceRatio: 8
   nodePools:
     worker:
-      class: "default"
       replicas: 2
-  nodeClasses:
-    default:
       cloneMode: "linkedClone"
       diskGiB: 50
       numCPUs: 6


### PR DESCRIPTION
### What does this PR do

Updates the capv values to match the latest schema changes (see https://github.com/giantswarm/cluster-vsphere/pull/232)

These changes have been tested locally against the linked PR:

```
Ran 20 of 32 Specs in 1659.396 seconds
SUCCESS! -- 20 Passed | 0 Failed | 0 Pending | 12 Skipped
PASS

Ginkgo ran 1 suite in 27m48.827700703s
Test Suite Passed
```

### Checklist

- [x] CHANGELOG.md has been updated
