### PR TITLE
Added support for Releases in standup CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for specifying the Release version when using the `standup` CLI
+
 ## [1.13.0] - 2024-07-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ standup --provider aws --context capa
 
 Flags:
       --cluster-values string         The path to the cluster app values
+      --release string                The version of Release to use to create the cluster (default "latest")
+      --release-commit string         The git commit to get the Release from (defaults to repo default branch)
       --cluster-version string        The version of the cluster app to install (default "latest")
       --context string                The kubernetes context to use (required)
       --control-plane-nodes int       The number of control plane nodes to wait for being ready (default 1)


### PR DESCRIPTION
### What does this PR do?

Towards: https://github.com/giantswarm/roadmap/issues/3557

Adds support for providing the Release version to use when creating a new cluster with `standup`

### Checklist

- [x] CHANGELOG.md has been updated
