### PR TITLE
Add wait-for-apps-ready flag to standup CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update CAPV values with `name` value
 
+### Added
+
+- Added a new `--wait-for-apps-ready` flag to the standup CLI that will wait until all default apps are installed
+
 ## [1.14.0] - 2024-07-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ standup --provider aws --context capa
 
 Flags:
       --cluster-values string         The path to the cluster app values
-      --release string                The version of Release to use to create the cluster (default "latest")
-      --release-commit string         The git commit to get the Release from (defaults to repo default branch)
       --cluster-version string        The version of the cluster app to install (default "latest")
       --context string                The kubernetes context to use (required)
       --control-plane-nodes int       The number of control plane nodes to wait for being ready (default 1)
@@ -125,6 +123,9 @@ Flags:
   -h, --help                          help for standup
       --output string                 The directory to store the results.json and kubeconfig in (default "./")
       --provider string               The provider (required)
+      --release string                The version of the Release to use (default "latest")
+      --release-commit string         The git commit to get the Release version from (defaults to main default if unset)
+      --wait-for-apps-ready           Wait until all default apps are installed
       --worker-nodes int              The number of worker nodes to wait for being ready (default 1)
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/giantswarm/clustertest v1.15.0
 	github.com/onsi/gomega v1.33.1
 	github.com/spf13/cobra v1.8.1
+	k8s.io/apimachinery v0.30.3
 	sigs.k8s.io/controller-runtime v0.18.4
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -159,7 +160,6 @@ require (
 	helm.sh/helm/v3 v3.15.2 // indirect
 	k8s.io/api v0.30.3 // indirect
 	k8s.io/apiextensions-apiserver v0.30.2 // indirect
-	k8s.io/apimachinery v0.30.3 // indirect
 	k8s.io/apiserver v0.30.2 // indirect
 	k8s.io/cli-runtime v0.30.3 // indirect
 	k8s.io/client-go v0.30.3 // indirect


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/giantswarm/giantswarm/issues/31367

Adds a new `--wait-for-apps-ready` flag to the `standup` CLI that will wait until all default apps are installed before finishing.

### Checklist

- [x] CHANGELOG.md has been updated
