### PR TITLE
Bump clustertest to 0.16.0 for CAPZ releases support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped clustertest to 0.16.0 with Releases support for CAPZ
+
 ## [1.16.0] - 2024-07-22
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 require (
 	dario.cat/mergo v1.0.0
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/clustertest v1.15.0
+	github.com/giantswarm/clustertest v1.16.0
 	github.com/onsi/gomega v1.33.1
 	github.com/spf13/cobra v1.8.1
 	k8s.io/apimachinery v0.30.3
@@ -57,7 +57,7 @@ require (
 	github.com/giantswarm/microerror v0.4.1 // indirect
 	github.com/giantswarm/organization-operator v1.6.3 // indirect
 	github.com/giantswarm/release-operator/v4 v4.2.0 // indirect
-	github.com/giantswarm/releases/sdk v0.4.0 // indirect
+	github.com/giantswarm/releases/sdk v0.5.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/clustertest v1.15.0 h1:qmmR48wg1c+SuYoWBefHUZBcDjdkfkXGypG0uMCiBjI=
-github.com/giantswarm/clustertest v1.15.0/go.mod h1:wq6D/sEqIrsD9Nlrwk1YSuCiqrfO8Ah3AQ4DQJ4lEl8=
+github.com/giantswarm/clustertest v1.16.0 h1:YcKnHTU/dBreYEtpIrGvr5PdQx8ywblXakBzYoHs1Kg=
+github.com/giantswarm/clustertest v1.16.0/go.mod h1:WQOv0fivZSM7A1C5GP6tAK+smUU7Z+fan8PDzbag4Dw=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=
 github.com/giantswarm/k8smetadata v0.25.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.57.0 h1:IMmho55Qq+WE+frJXcTBhx19+J54xwu/j4+pGU5YecA=
@@ -127,8 +127,8 @@ github.com/giantswarm/organization-operator v1.6.3 h1:hwfszk6pm6omT3bzJiD8+h4v5G
 github.com/giantswarm/organization-operator v1.6.3/go.mod h1:wtchBVnf4aOrZb/1pZO8szfrRPXsZbbyovfQRZPaIEo=
 github.com/giantswarm/release-operator/v4 v4.2.0 h1:8aU8V3BlF/sKmYG1MgcPGXs8Q/cOlZfhgK4/oBfMPbg=
 github.com/giantswarm/release-operator/v4 v4.2.0/go.mod h1:/ew0vh4BnfJqOddNTcm7iAHvm7g4MBp5C+pxi+H4ydk=
-github.com/giantswarm/releases/sdk v0.4.0 h1:wua8bYGtQktXkEPQJgZFUrivpev1yaV6DwNF08OmiwE=
-github.com/giantswarm/releases/sdk v0.4.0/go.mod h1:EVc38EK1t7VsZPZnFFER1haLMkk7qBC6H0o8bOWWkak=
+github.com/giantswarm/releases/sdk v0.5.0 h1:tmCzXT4DkZ8QdxuVXzNycf1pdH1ImbshbVYqXaCN2mw=
+github.com/giantswarm/releases/sdk v0.5.0/go.mod h1:EVc38EK1t7VsZPZnFFER1haLMkk7qBC6H0o8bOWWkak=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=


### PR DESCRIPTION
### What does this PR do?

### Checklist

- [x] CHANGELOG.md has been updated
