### PR TITLE
remove node classes from capvcd values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update capvcd values to not include node classes.
+
 ## [1.25.1] - 2024-09-19
 
 ### Fixed

--- a/pkg/clusterbuilder/providers/capvcd/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capvcd/values/cluster_values.yaml
@@ -23,17 +23,14 @@ global:
       usernameClaim: "email"
   nodePools:
     worker:
-      class: default
+      sizingPolicy: m1.large
+      diskSizeGB: 30
       replicas: 2
   providerSpecific:
     org: GIANT_SWARM
     ovdc: Org-GIANT-SWARM
     site: "https://cd.neoedge.cloud"
     ovdcNetwork: GS-ISOLATED
-    nodeClasses:
-      default:
-        sizingPolicy: m1.large
-        diskSizeGB: 30
     userContext:
       secretRef:
         secretName: vcd-credentials


### PR DESCRIPTION
https://github.com/giantswarm/cluster-cloud-director/pull/355
https://github.com/giantswarm/giantswarm/issues/31193

### What does this PR do?

We are getting rid of node classes in the capvcd chart and need to reflect that in the tests

### Checklist

- [ ] CHANGELOG.md has been updated
