### PR TITLE
Set LB IPs to reserve to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change number of reserved IPs for LB in vSphere pool to 1.
+
 ## [1.25.5] - 2024-10-08
 
 ### Fixed

--- a/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml
@@ -1,5 +1,4 @@
 global:
-global:
   metadata:
     description: "E2E Test cluster"
     name: "{{ .ClusterName }}"

--- a/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml
@@ -1,4 +1,5 @@
 global:
+global:
   metadata:
     description: "E2E Test cluster"
     name: "{{ .ClusterName }}"
@@ -9,6 +10,7 @@ global:
         ipPoolName: "wc-cp-ips" # [string] Ip for control plane will be drawn from this GlobalInClusterIPPool (for gcapeverde it's 10.10.222.232 - 10.10.222.238 inclusive)
       loadBalancers:
         ipPoolName: "svc-lb-ips" # [string] Ip for control plane will be drawn from this GlobalInClusterIPPool (for gcapeverde it's 10.10.222.245 - 10.10.222.249 inclusive)
+        numberOfIps: 1
     baseDomain: test.gigantic.io
   controlPlane:
     replicas: 1


### PR DESCRIPTION
We introduced this change recently to reserve 3 IPs by default per WC (arbitrary sane default for customers) but our pool in gcapeverde has only 10 IPs so we fill it up quickly.

### What does this PR do?

### Checklist

- [x] CHANGELOG.md has been updated
