### PR TITLE
Update CAPVCD values for provider version v0.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update CAPVCD values for provider version v0.61.0
+
 ## [1.25.6] - 2024-10-08
 
 ### Changed

--- a/pkg/clusterbuilder/providers/capvcd/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capvcd/values/cluster_values.yaml
@@ -1,11 +1,15 @@
+cluster:
+  providerIntegration:
+    components:
+      systemd:
+        timesyncd:
+          ntp:
+            - "10.205.105.253"
 global:
   connectivity:
     network:
       loadBalancers:
         vipSubnet: "10.205.9.254/24"
-    ntp:
-      servers:
-        - "10.205.105.253"
     proxy:
       enabled: true
       httpProxy: "http://10.205.105.253:3128"
@@ -18,13 +22,14 @@ global:
     name: "{{ .ClusterName }}"
   controlPlane:
     replicas: 3
-    diskSizeGB: 30
-    sizingPolicy: m1.large
     oidc:
       clientId: "dex-k8s-authenticator"
       groupsClaim: "groups"
       issuerUrl: "https://dex.gerbil.test.gigantic.io"
       usernameClaim: "email"
+    machineTemplate:
+      diskSizeGB: 30
+      sizingPolicy: m1.large
   nodePools:
     worker:
       sizingPolicy: m1.large


### PR DESCRIPTION
### What does this PR do?

Updates CAPVCD values to support rendering CP nodes with the shared cluster chart

### Checklist

- [x] CHANGELOG.md has been updated
