### PR TITLE
CAPA: use lower heartbeat timeout to allow spot instances to terminate more quickly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CAPA: use lower heartbeat timeout to allow spot instances to terminate more quickly
+
 ## [1.27.3] - 2024-11-13
 
 ### Changed

--- a/pkg/clusterbuilder/providers/capa/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capa/values/cluster_values.yaml
@@ -19,6 +19,15 @@ global:
       maxSize: 5
       minSize: 2
       rootVolumeSizeGB: 25
+
+      # With spot instances, aws-node-termination-handler may not receive any ASG lifecycle hook events
+      # and we don't want to wait for the default 30 minutes of heartbeat timeout before instances
+      # terminate. That would fail the tests. This can be fixed once heartbeats are implemented
+      # (https://github.com/aws/aws-node-termination-handler/issues/493), since then we would reduce
+      # cluster-aws's defaults to a low value, let's say `heartbeatTimeout: 5m` and `globalTimeout: 30m`.
+      awsNodeTerminationHandler:
+        heartbeatTimeoutSeconds: 100
+
       spotInstances:
         enabled: true
         maxPrice: 0.2960

--- a/pkg/clusterbuilder/providers/capa/values/private-cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capa/values/private-cluster_values.yaml
@@ -52,6 +52,15 @@ global:
       maxSize: 5
       minSize: 2
       rootVolumeSizeGB: 25
+
+      # With spot instances, aws-node-termination-handler may not receive any ASG lifecycle hook events
+      # and we don't want to wait for the default 30 minutes of heartbeat timeout before instances
+      # terminate. That would fail the tests. This can be fixed once heartbeats are implemented
+      # (https://github.com/aws/aws-node-termination-handler/issues/493), since then we would reduce
+      # cluster-aws's defaults to a low value, let's say `heartbeatTimeout: 5m` and `globalTimeout: 30m`.
+      awsNodeTerminationHandler:
+        heartbeatTimeoutSeconds: 100
+
       spotInstances:
         enabled: true
         maxPrice: 0.2960


### PR DESCRIPTION
Related to https://github.com/giantswarm/aws-nth-crossplane-resources/pull/7, towards https://github.com/giantswarm/giantswarm/issues/31843 and https://github.com/giantswarm/giantswarm/issues/32232

Requires https://github.com/giantswarm/cluster-aws/pull/960 ported to `cluster-aws@main`.

### What does this PR do?

See comment in code. Tests would time out if we don't specify this together with EC2 Spot instance usage.

### Checklist

- [x] CHANGELOG.md has been updated
