### PR TITLE
Strip teleport prefix from MC name in log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix linting issues.
+- Strip Teleport prefix from MC name in log output
 
 ## [1.31.0] - 2025-02-20
 

--- a/pkg/standup/standup.go
+++ b/pkg/standup/standup.go
@@ -3,6 +3,7 @@ package standup
 import (
 	"context"
 	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/gomega" // nolint:staticcheck
@@ -60,7 +61,10 @@ func (c *Client) Standup(cluster *application.Cluster) (*application.Cluster, er
 	Eventually(func() error {
 		logger.Log("Checking connection to MC is available.")
 		logger.Log("MC API Endpoint: '%s'", c.Framework.MC().GetAPIServerEndpoint())
-		logger.Log("MC name: '%s'", c.Framework.MC().GetClusterName())
+		mcName := c.Framework.MC().GetClusterName()
+		// Strip the Teleport prefix that is automatically added to the cluster name so we just log out the installation name
+		mcName = strings.TrimPrefix(mcName, "teleport.giantswarm.io-")
+		logger.Log("MC name: '%s'", mcName)
 		return c.Framework.MC().CheckConnection()
 	}).
 		WithTimeout(5 * time.Minute).


### PR DESCRIPTION
### What does this PR do?

Before:

```
{"level":"info","ts":"2025-06-06T04:30:29Z","msg":"MC name: 'teleport.giantswarm.io-goat'"}
```

After:

```
{"level":"info","ts":"2025-06-06T04:30:29Z","msg":"MC name: 'goat'"}
```

### Checklist

- [x] CHANGELOG.md has been updated
