### PR TITLE
CAPA: migrate to plural `vpcCidrs` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- CAPA: migrate to plural `vpcCidrs` value
+
 ## [1.31.1] - 2025-06-09
 
 ### Fixed

--- a/pkg/clusterbuilder/providers/capa/values/private-cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capa/values/private-cluster_values.yaml
@@ -11,6 +11,8 @@ global:
       mode: public
     network:
       vpcCidr: 10.{{ index .ExtraValues "CIDRSecondOctet" }}.0.0/18
+      vpcCidrs:
+        - 10.{{ index .ExtraValues "CIDRSecondOctet" }}.0.0/18
     proxy:
       enabled: true
       httpProxy: http://proxy.goatproxy.gaws.gigantic.io:4000


### PR DESCRIPTION
### What does this PR do?

Required to pass E2E tests after https://github.com/giantswarm/cluster-aws/pull/1250

### Checklist

- [x] CHANGELOG.md has been updated
