### PR TITLE
Decrease instanceWarmup to 3 minutes for CAPA workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Decrease `instanceWarmup` to 3 minutes for CAPA worker nodes to speed up upgrade test case
+
 ## [1.32.0] - 2025-06-24
 
 ### Added

--- a/pkg/clusterbuilder/providers/capa/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capa/values/cluster_values.yaml
@@ -24,6 +24,8 @@ global:
       # cluster-aws's defaults to a low value, let's say `heartbeatTimeout: 5m` and `globalTimeout: 30m`.
       awsNodeTerminationHandler:
         heartbeatTimeoutSeconds: 100
+      # Speed up the ASG cycle when upgrading to avoid having long running test case
+      instanceWarmup: 180
 
   apps:
     externalDns:

--- a/pkg/clusterbuilder/providers/capa/values/managed-cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capa/values/managed-cluster_values.yaml
@@ -23,6 +23,8 @@ global:
       maxSize: 3
       minSize: 2
       rootVolumeSizeGB: 25
+      # Speed up the ASG cycle when upgrading to avoid having long running test case
+      instanceWarmup: 180
 
   apps:
     clusterAutoscaler:

--- a/pkg/clusterbuilder/providers/capa/values/private-cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capa/values/private-cluster_values.yaml
@@ -57,6 +57,8 @@ global:
       # cluster-aws's defaults to a low value, let's say `heartbeatTimeout: 5m` and `globalTimeout: 30m`.
       awsNodeTerminationHandler:
         heartbeatTimeoutSeconds: 100
+      # Speed up the ASG cycle when upgrading to avoid having long running test case
+      instanceWarmup: 180
 
   apps:
     certManager:


### PR DESCRIPTION
### What does this PR do?

- Decrease `instanceWarmup` to 3 minutes for CAPA worker nodes to speed up upgrade test case


### Checklist

- [x] CHANGELOG.md has been updated
