### PR TITLE
Revert "Adjust CAPA private cluster tests to suit `garm` setup (#237)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Adjust CAPA private cluster tests to suit `garm` setup
-
 ## [1.33.0] - 2025-06-26
 
 ### Changed

--- a/pkg/clusterbuilder/providers/capa/private_cluster.go
+++ b/pkg/clusterbuilder/providers/capa/private_cluster.go
@@ -33,10 +33,10 @@ func (c *PrivateClusterBuilder) NewClusterApp(clusterName string, orgName string
 		orgName = utils.GenerateRandomName("t")
 	}
 
-	// WC CIDRs have to not overlap and be in the 10.129. - 10.159. range, so
+	// WC CIDRs have to not overlap and be in the 10.225. - 10.255. range, so
 	// we select a random number in that range and set it as the second octet.
 	//nolint:gosec
-	randomOctet := rand.Intn(31) + 129 // Generates a number between 129 and 159 inclusive.
+	randomOctet := rand.Intn(30) + 225
 	cidrOctet := fmt.Sprintf("%d", randomOctet)
 	templateValues := &application.TemplateValues{
 		ClusterName:  clusterName,


### PR DESCRIPTION
This reverts commit 80b73f50c600b8211002876d6b3ecf12441041ad but keeps the changes for the proxy settings

I've found some issues with garm's base domain. I'll switch back once that's sorted out

### What does this PR do?

### Checklist

- [x] CHANGELOG.md has been updated
