### PR TITLE
feat: add support for AKS provider (cluster-aks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cluster creation on AKS (CAPZ managed control plane), available via the `aks` KubeContext.
+
+### Changed
+
 - Docker: Cross-compile binaries.
 
 ## [6.0.1] - 2026-05-08

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ contexts:
     user: glippy-admin
   name: capz
 - context:
+    cluster: glippy
+    user: glippy-admin
+  name: aks
+- context:
     cluster: grizzly
     user: grizzly-admin
   name: capa

--- a/cmd/standup/main.go
+++ b/cmd/standup/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/giantswarm/cluster-standup-teardown/v6/cmd/standup/types"
 	cb "github.com/giantswarm/cluster-standup-teardown/v6/pkg/clusterbuilder"
+	"github.com/giantswarm/cluster-standup-teardown/v6/pkg/clusterbuilder/providers/capz"
 	"github.com/giantswarm/cluster-standup-teardown/v6/pkg/standup"
 	"github.com/giantswarm/cluster-standup-teardown/v6/pkg/values"
 )
@@ -137,8 +138,9 @@ func run(cmd *cobra.Command, args []string) error {
 			WithAppVersions(clusterVersion)
 	}
 
-	if provider == application.ProviderEKS {
-		// As EKS has no control plane we only check for worker nodes being ready
+	if provider == application.ProviderEKS || provider == capz.ProviderAKS {
+		// As EKS and AKS have a managed control plane (no control-plane nodes are
+		// visible in the workload cluster) we only check for worker nodes being ready
 		clusterReadyFns = []func(wcClient *client.Client){func(wcClient *client.Client) {
 			_ = wait.For(
 				wait.AreNumNodesReady(context.Background(), wcClient, workerNodes, client.DoesNotHaveLabels{"node-role.kubernetes.io/control-plane"}),

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/giantswarm/microerror v0.4.1 // indirect
 	github.com/giantswarm/organization-operator v1.6.4 // indirect
 	github.com/giantswarm/release-operator/v4 v4.2.1 // indirect
-	github.com/giantswarm/releases/sdk v0.12.0 // indirect
+	github.com/giantswarm/releases/sdk v0.13.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
@@ -84,7 +84,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/go-github/v84 v84.0.0 // indirect
 	github.com/google/go-github/v88 v88.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/giantswarm/organization-operator v1.6.4 h1:t0G0hoB7TfeGzRnr58NIwO6LAm
 github.com/giantswarm/organization-operator v1.6.4/go.mod h1:Rw9gG/ReI5YfvoC85F9H5wH2aWguUR7JY/NfTjZC2Jc=
 github.com/giantswarm/release-operator/v4 v4.2.1 h1:qqYHlLGsoHe0FZkkHzKDueGHoMZUq/SA6boaPXo5WtU=
 github.com/giantswarm/release-operator/v4 v4.2.1/go.mod h1:9TSANhfSsprjwD2NRI+jXMo7MDedt+/oVdOCEGPjaCE=
-github.com/giantswarm/releases/sdk v0.12.0 h1:zL62k34FtB2Yv+Y6K739D/eKHMl0pqauy2C/W2Sex8I=
-github.com/giantswarm/releases/sdk v0.12.0/go.mod h1:HFalCuZ2YHtfMXM/Yb4Mr7oF68itKYHSdpFLPM+/Xbk=
+github.com/giantswarm/releases/sdk v0.13.0 h1:xEAO+rI820X/XTeMDF2IowmBKEbHQ0PS5LkpDAMRmmY=
+github.com/giantswarm/releases/sdk v0.13.0/go.mod h1:YBRAKlJhZkt3hIxOIuQN5CD7A67it67s7GjGaE1yedU=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
@@ -208,8 +208,6 @@ github.com/google/gnostic-models v0.7.1/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7O
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v84 v84.0.0 h1:I/0Xn5IuChMe8TdmI2bbim5nyhaRFJ7DEdzmD2w+yVA=
-github.com/google/go-github/v84 v84.0.0/go.mod h1:WwYL1z1ajRdlaPszjVu/47x1L0PXukJBn73xsiYrRRQ=
 github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
 github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
@@ -217,8 +215,8 @@ github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJ
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/vP9vJGqPwcdqsWjOt+V8J7+bTc=
-github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
+github.com/google/pprof v0.0.0-20260507013755-92041b743c96 h1:YDDnaZ9afWajDboPMt9Vikqca/yWAX7KAxVzb4lJU1M=
+github.com/google/pprof v0.0.0-20260507013755-92041b743c96/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
@@ -303,8 +301,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
-github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
+github.com/onsi/ginkgo/v2 v2.31.0 h1:GtuJos5DFUV9EerYJo8RhYxosYNGvOdDE5haKq6Grfs=
+github.com/onsi/ginkgo/v2 v2.31.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
 github.com/onsi/gomega v1.42.1 h1:iN1rCUX+44NZ1Dc97MPoeFYbFR0vh8zxoxMFwKdyZ6I=
 github.com/onsi/gomega v1.42.1/go.mod h1:REff/hsDsodHoKlWsP2mAPhu1+5/6hVYNf9rIEBpeSg=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/pkg/clusterbuilder/client.go
+++ b/pkg/clusterbuilder/client.go
@@ -157,7 +157,7 @@ func GetClusterBuilderForContext(context string) (ClusterBuilder, error) {
 		&capmox.ClusterBuilder{},
 		&capv.ClusterBuilder{}, &capz.PrivateClusterBuilder{},
 		&capvcd.ClusterBuilder{},
-		&capz.ClusterBuilder{},
+		&capz.ClusterBuilder{}, &capz.ManagedClusterBuilder{},
 	}
 
 	for _, builder := range knownBuilders {

--- a/pkg/clusterbuilder/client_test.go
+++ b/pkg/clusterbuilder/client_test.go
@@ -52,6 +52,11 @@ func Test_GetClusterBuilderForContext(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			inputValues:   "aks",
+			expected:      &capz.ManagedClusterBuilder{},
+			expectedError: false,
+		},
+		{
 			inputValues:   "CAPA",
 			expected:      &capa.ClusterBuilder{},
 			expectedError: false,

--- a/pkg/clusterbuilder/providers/capz/managed_cluster.go
+++ b/pkg/clusterbuilder/providers/capz/managed_cluster.go
@@ -1,0 +1,56 @@
+package capz
+
+import (
+	_ "embed"
+
+	"github.com/giantswarm/cluster-standup-teardown/v6/pkg/values"
+
+	"github.com/giantswarm/clustertest/v5/pkg/application"
+	"github.com/giantswarm/clustertest/v5/pkg/organization"
+	"github.com/giantswarm/clustertest/v5/pkg/utils"
+)
+
+// ProviderAKS is the provider name used for the CAPZ managed (AKS) cluster app.
+//
+// The clustertest `application` package does not yet expose a constant for AKS,
+// so we define it here. The provider name determines the cluster app to use
+// (i.e. `cluster-aks`).
+const ProviderAKS application.Provider = "aks"
+
+var (
+	//go:embed values/managed-cluster_values.yaml
+	baseManagedClusterValues string
+)
+
+// ManagedClusterBuilder is the CAPZ AKS ClusterBuilder
+type ManagedClusterBuilder struct {
+	CustomKubeContext string
+}
+
+// NewClusterApp builds a new CAPZ AKS cluster App
+func (c *ManagedClusterBuilder) NewClusterApp(clusterName string, orgName string, clusterValuesOverrides []string) *application.Cluster {
+	if clusterName == "" {
+		clusterName = utils.GenerateRandomName("t")
+	}
+	if orgName == "" {
+		orgName = utils.GenerateRandomName("t")
+	}
+
+	return application.NewClusterApp(clusterName, ProviderAKS).
+		WithOrg(organization.New(orgName)).
+		WithAppValues(
+			values.MustMergeValues(append([]string{baseManagedClusterValues}, clusterValuesOverrides...)...),
+			&application.TemplateValues{
+				ClusterName:  clusterName,
+				Organization: orgName,
+			},
+		)
+}
+
+// KubeContext returns the known KubeConfig context that this builder expects
+func (c *ManagedClusterBuilder) KubeContext() string {
+	if c.CustomKubeContext != "" {
+		return c.CustomKubeContext
+	}
+	return "aks"
+}

--- a/pkg/clusterbuilder/providers/capz/values/managed-cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capz/values/managed-cluster_values.yaml
@@ -1,0 +1,41 @@
+global:
+  metadata:
+    name: "{{ .ClusterName }}"
+    description: "E2E Test cluster"
+    organization: "{{ .Organization }}"
+  connectivity:
+    baseDomain: azuretest.gigantic.io
+  providerSpecific:
+    location: "westeurope"
+    subscriptionId: 6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3
+  controlPlane:
+    sku:
+      tier: Standard
+  # We need to pass the node pools otherwise the test called "has all the worker nodes running" will fail because it
+  # expects to find the number of worker nodes in the helm values, but the value is not there if we don't pass it, as
+  # it's defaulted in the chart template.
+  nodePools:
+    system:
+      mode: System
+      vmSize: Standard_D2s_v3
+      osDiskSizeGB: 128
+      osDiskType: Managed
+      osType: Linux
+      minSize: 1
+      maxSize: 2
+      availabilityZones:
+        - "1"
+        - "2"
+        - "3"
+    workers:
+      mode: User
+      vmSize: Standard_D4s_v3
+      osDiskSizeGB: 128
+      osDiskType: Managed
+      osType: Linux
+      minSize: 1
+      maxSize: 2
+      availabilityZones:
+        - "1"
+        - "2"
+        - "3"


### PR DESCRIPTION
### What does this PR do?

Add cluster creation on AKS (CAPZ managed control plane), available via the `aks` KubeContext.

Towards https://github.com/giantswarm/giantswarm/issues/36639

### Checklist

- [x] CHANGELOG.md has been updated
