### PR TITLE
feat: Cloud Director: Configure E2E tests to pull images through a local Zot instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Cloud Director: Configure E2E tests to pull images through a local Zot instance.
+
 ## [6.0.2] - 2026-07-26
 
 ### Added

--- a/pkg/clusterbuilder/providers/capvcd/values/cluster_values.yaml
+++ b/pkg/clusterbuilder/providers/capvcd/values/cluster_values.yaml
@@ -6,6 +6,18 @@ cluster:
           ntp:
             - "10.205.105.253"
 global:
+  components:
+    containerd:
+      containerRegistries:
+        # use a local Zot registry on the neoedge proxy machine for caching
+        gsoci.azurecr.io:
+          - endpoint: 10.205.105.253:5000
+            insecure: true
+      # disable use of the MC Zot registry
+      managementClusterRegistryCache:
+        enabled: false
+      localRegistryCache:
+        enabled: false
   connectivity:
     network:
       loadBalancers:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/36842

### What does this PR do?

Configures VCD clusters to pull images through Zot on the Neoedge proxy.

### Checklist

- [x] CHANGELOG.md has been updated
